### PR TITLE
Fix bugs in searching/sorting jobs

### DIFF
--- a/client/src/components/JobFilters.js
+++ b/client/src/components/JobFilters.js
@@ -1,7 +1,6 @@
 import React from "react";
 import "./JobFilters.scss";
 
-
 const JobFilters = ({
   onSetJobTitle,
   onSetEmploymentTypeFT,
@@ -18,96 +17,136 @@ const JobFilters = ({
   regions,
   regionId,
   organizations,
-  organizationId,
-  sortBy,
-  handleChangeSortBy
-}) => (<aside className="filter-bar-container">
-  <div className="filter-column">
-    <div className="filter-wrapper">
-      <p className="filter-title">Job Title</p>
-      <input type="search" className="title-input" name="keywords" placeholder="Job Title" onChange={onSetJobTitle} />
-    </div>
-    <div className="filter-wrapper">
-      <p className="filter-title">
-        Location
-      </p>
-      <input value={distanceZip} placeholder="Zip Code" onChange={event => {
-        onSetDistanceZip(event);
-      }} className="zip-input" />
-    </div>
-  </div>
-  <div className="filter-column">
-    <div className="filter-wrapper">
-      <p className="filter-title">Distance</p>
-      <select value={distanceRadius} onChange={event => {
-        onSetDistanceRadius(event);
-      }} className="distance-selector">
-        <option value="">(Any)</option>
-        <option value="5">5 miles</option>
-        <option value="10">10 miles</option>
-        <option value="25">25 miles</option>
-        <option value="50">50 miles</option>
-      </select>
-    </div>
-  </div>
-  <div className="filter-column">
-    <div className="filter-wrapper">
-      <p className="filter-title">Organization</p>
-      <div>
-        <select onChange={event => {
-          onSetOrganization(event);
-        }} value={organizationId} className="organization-selector">
-          <option value="">(Any)</option>
+  organizationId
+}) => (
+  <aside className="filter-bar-container">
+    <div className="filter-column">
+      <div className="filter-wrapper">
+        <p className="filter-title">Job Title</p>
+        <input
+          type="search"
+          className="title-input"
+          name="keywords"
+          placeholder="Job Title"
+          onChange={onSetJobTitle}
+        />
+      </div>
+      <div className="filter-wrapper">
+        <p className="filter-title">Location</p>
+        <div style={{ display: "flex", flexDirection: "row" }}>
+          <input
+            value={distanceZip}
+            placeholder="Zip Code"
+            onChange={event => {
+              onSetDistanceZip(event);
+            }}
+            className="zip-input"
+          />
 
-          {organizations &&
-            organizations.map(org => {
-              return (<option key={org.id} value={org.id}>
-                {org.name}
-              </option>);
-            })}
+          <select
+            value={distanceRadius}
+            onChange={event => {
+              onSetDistanceRadius(event);
+            }}
+            style={{
+              visibility:
+                distanceZip && distanceZip.length === 5 ? "visible" : "hidden"
+            }}
+            className="distance-selector"
+          >
+            <option value="0">(Exact)</option>
+            <option value="5">5 miles</option>
+            <option value="10">10 miles</option>
+            <option value="25">25 miles</option>
+            <option value="50">50 miles</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div className="filter-column">
+      <div className="filter-wrapper">
+        <p className="filter-title">Organization</p>
+        <div>
+          <select
+            onChange={event => {
+              onSetOrganization(event);
+            }}
+            value={organizationId}
+            className="organization-selector"
+          >
+            <option value="">(Any)</option>
+
+            {organizations &&
+              organizations.map(org => {
+                return (
+                  <option key={org.id} value={org.id}>
+                    {org.name}
+                  </option>
+                );
+              })}
+          </select>
+        </div>
+      </div>
+      <div className="filter-wrapper">
+        <p className="filter-title">Region</p>
+        <select
+          className="region-selector"
+          value={regionId}
+          onChange={e => onSetRegionId(e.target.value)}
+        >
+          <option key="0" value="">
+            (Any)
+          </option>
+          {regions
+            ? regions.map(region => (
+                <option key={region.id} value={region.id}>
+                  {region.name}
+                </option>
+              ))
+            : null}
         </select>
       </div>
     </div>
-    <div className="filter-wrapper">
-      <p className="filter-title">Region</p>
-      <select className="region-selector" value={regionId} onChange={e => onSetRegionId(e.target.value)}>
-        <option key="0" value="">
-          (Any)
-        </option>
-        {regions
-          ? regions.map(region => (<option key={region.id} value={region.id}>
-            {region.name}
-          </option>))
-          : null}
-      </select>
+
+    <div className="filter-column">
+      <div className="filter-wrapper">
+        <p className="filter-title">Employment Type</p>
+        <div className="filter-options">
+          <input
+            name="full-time"
+            type="checkbox"
+            checked={employmentTypeFT}
+            onChange={event => {
+              onSetEmploymentTypeFT(event.target.checked);
+            }}
+          />
+          <p>Full Time</p> <br />
+        </div>
+        <div className="filter-options">
+          <input
+            name="part-time"
+            type="checkbox"
+            checked={employmentTypePT}
+            onChange={event => {
+              onSetEmploymentTypePT(event.target.checked);
+            }}
+          />
+          <p>Part Time</p> <br />
+        </div>
+        <div className="filter-options">
+          <input
+            name="full-time"
+            type="checkbox"
+            checked={employmentTypeUnspecified}
+            onChange={event => {
+              // onSetEmploymentTypeFT(event.target.checked);
+            }}
+          />
+          <p>Unspecified</p>
+        </div>
+      </div>
     </div>
-  </div>
-
-
-
-  <div className="filter-column">
-    <div className="filter-wrapper">
-      <p className="filter-title">Employment Type</p>
-      <div className="filter-options">
-        <input name="full-time" type="checkbox" checked={employmentTypeFT} onChange={event => {
-          onSetEmploymentTypeFT(event.target.checked);
-        }} />
-        <p>Full Time</p> <br />
-      </div>
-      <div className="filter-options">
-        <input name="part-time" type="checkbox" checked={employmentTypePT} onChange={event => {
-          onSetEmploymentTypePT(event.target.checked);
-        }} />
-        <p>Part Time</p> <br />
-      </div>
-      <div className="filter-options">
-        <input name="full-time" type="checkbox" checked={employmentTypeUnspecified} onChange={event => {
-          // onSetEmploymentTypeFT(event.target.checked);
-        }} />
-        <p>Unspecified</p>
-      </div>
-    </div>
-  </div>
-</aside>)
+  </aside>
+);
 
 export default JobFilters;

--- a/client/src/components/JobPostings.js
+++ b/client/src/components/JobPostings.js
@@ -44,8 +44,14 @@ class JobPostings extends React.Component {
             </div>
           </div>
           <div className="middle-posting">
-            <h3 style={{ marginTop: "0", marginBottom: "0" }}>{job.title}</h3>
-            <h4>{job.organization_name}</h4>
+            <h3 style={{ marginTop: "0", marginBottom: "0" }}>
+              <a href={job.info_link}>{job.title}</a>
+            </h3>
+            <h4>
+              <a href={"/organizations/" + job.organization_id}>
+                {job.organization_name}
+              </a>
+            </h4>
             <p>
               {job.summary.toLowerCase().startsWith("http") ? (
                 <a href={job.summary} target="_blank" rel="noopener noreferrer">

--- a/client/src/components/JobPostings.scss
+++ b/client/src/components/JobPostings.scss
@@ -141,14 +141,14 @@ h4 {
 .org-img-wrapper {
   overflow: hidden;
   display: flex;
-  justify-content: center;
+  justify-content: left;
   flex: 0 0 70%;
 }
 
 .org-img {
   max-width: 90%;
   max-height: 90%;
-  margin: auto;
+  margin: auto auto auto 0;
   object-fit: contain;
 }
 

--- a/client/src/components/Jobs.js
+++ b/client/src/components/Jobs.js
@@ -23,7 +23,7 @@ class Jobs extends React.Component {
     employmentTypeFT: false,
     employmentTypePT: false,
     employmentTypeUnspecified: false,
-    distanceRadius: "",
+    distanceRadius: "0",
     distanceZip: "",
     regionId: "",
     filteredJobs: [],
@@ -223,21 +223,19 @@ class Jobs extends React.Component {
   };
 
   getDistanceFilter = (distanceRadius, originZip) => {
-    console.log("hit dist");
-    if (originZip.length === 5) {
-      //if  radius is "any" and length is 5, then set radius to 5
-      if (distanceRadius === "") {
-        this.setState({ distanceRadius: 5, isBusy: true });
+    if (originZip && originZip.length === 5) {
+      if (Number(distanceRadius) === 0) {
+        return job => job.zipcode === originZip || !job.zipcode;
+      } else {
+        return job => {
+          // dist returns null if either arg is "" or invalid
+          const distanceDifference = dist(job.zipcode, originZip);
+          // return distanceDifference == 0 || distanceDifference && distanceDifference <= Number(distanceRadius)
+          return (
+            !distanceDifference || distanceDifference <= Number(distanceRadius)
+          );
+        };
       }
-      return job => {
-        // dist returns null if either arg is "" or invalid
-        const distanceDifference = dist(job.zipcode, originZip);
-        // return distanceDifference == 0 || distanceDifference && distanceDifference <= Number(distanceRadius)
-        return (
-          distanceDifference == 0 ||
-          distanceDifference <= Number(distanceRadius)
-        ); // show nulls and invalid zips
-      };
     } else {
       return job => job;
     }

--- a/client/src/utils/utils.js
+++ b/client/src/utils/utils.js
@@ -1,7 +1,7 @@
 import { codes } from "./mapCodes";
 
 //calculate radius from zipcode
-var lookup = function (zip) {
+var lookup = function(zip) {
   if (
     zip !== null &&
     zip !== undefined &&
@@ -13,11 +13,11 @@ var lookup = function (zip) {
   return codes[zip];
 };
 
-var deg2rad = function (value) {
+var deg2rad = function(value) {
   return value * 0.017453292519943295;
 };
 
-export const dist = function (zipA, zipB) {
+export const dist = function(zipA, zipB) {
   zipA = lookup(zipA);
   zipB = lookup(zipB);
   if (!zipA || !zipB) {
@@ -30,11 +30,11 @@ export const dist = function (zipA, zipB) {
   var distance =
     Math.sin(zipALatitudeRadians) * Math.sin(zipBLatitudeRadians) +
     Math.cos(zipALatitudeRadians) *
-    Math.cos(zipBLatitudeRadians) *
-    Math.cos(deg2rad(zipA.longitude - zipB.longitude));
+      Math.cos(zipBLatitudeRadians) *
+      Math.cos(deg2rad(zipA.longitude - zipB.longitude));
 
   distance = Math.acos(distance) * 3958.56540656;
-  return Math.round(distance, 4);
+  return Number(distance.toFixed(4));
 };
 
 // Software License Agreement (BSD License)

--- a/services/job_service.js
+++ b/services/job_service.js
@@ -21,7 +21,10 @@ const getAll = () => {
         title: row.job_title,
         summary: row.job_summary,
         location: row.job_location,
-        zipcode: row.job_zip_code,
+        zipcode:
+          row.job_zip_code && row.job_zip_code.length >= 5
+            ? row.job_zip_code.slice(0, 5)
+            : "",
         post_date: row.job_post_date,
         hours: row.full_or_part,
         salary: row.salary,

--- a/services/organization_service.js
+++ b/services/organization_service.js
@@ -56,7 +56,7 @@ const get = id => {
   const sql = `
       select o.id, o.name, o.url, o.logo, o.mission, o.description,
         o.street, o.suite, o.city, o.state, o.zip, o.latitude, o.longitude,
-        o.phone, o.email, o.is_user_created, o.is_approved
+        o.phone, o.email, o.is_user_created, o.is_approved,
         count(j.organization_id) as job_count
       from organizations o
       left join jobs j on o.id = j.organization_id


### PR DESCRIPTION
Clean up zip codes for jobs so they are all five digits or an empty string.
For location searches, user enters zip code first. If proper zip code is entered, then radius drop-down shows options of (Exact) or various distances, to combine the exact zip code search with the distance-based search.  When a location-based search is done, jobs without a valid zip code will be included in the result set, but sorted to the end (regardless of the user's sort selection).
Fixed bug where distance calculation was rounding to the nearest mile.
Closes #166 - make Position Title and organization names into links that go to the service rpovider's job listing, or the Job for Hope Organizationview, respectively.